### PR TITLE
feat: support for multiple contracts in a workspace

### DIFF
--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -12,9 +12,6 @@ use crate::{
 pub struct BuildCmd {
     /// The cosmwasm-schema file to use
     pub schema: PathBuf,
-    /// Optional wasm binary file to include in the documentation file
-    #[arg(short, long)]
-    pub wasm: Option<PathBuf>,
 }
 
 impl Executable for BuildCmd {
@@ -23,15 +20,7 @@ impl Executable for BuildCmd {
         let idl = crate::idl_loader::try_load(&dir_string)?;
         info!("IDL file loaded successfully.");
 
-        let wasm_file = if let Some(w) = &self.wasm {
-            info!("Reading the wasm file...");
-            std::fs::read(w).ok()
-        }
-        else {
-            trace!("No wasm binary provided - it will not be included.");
-            None
-        };
-        let api = crate::idl_processor::process_idl(&idl, wasm_file.as_ref())?;
+        let api = crate::idl_processor::process_idl(&idl)?;
         let api = serde_json::to_string_pretty(&api)?;
         fs::write(self.schema.join("swagger.json"), &api)?;
         Ok(())

--- a/src/idl_loader/error.rs
+++ b/src/idl_loader/error.rs
@@ -8,4 +8,6 @@ pub enum IdlError {
     JsonDeserializeError(#[from] serde_json::Error),
     #[error("IO Error: {0}")]
     IoError(#[from] std::io::Error),
+    #[error("Path Error: {0}")]
+    PathError(#[from] std::path::StripPrefixError),
 }

--- a/src/idl_loader/loaded_idl.rs
+++ b/src/idl_loader/loaded_idl.rs
@@ -1,0 +1,5 @@
+
+pub struct LoadedIdl {
+    pub idl: serde_json::Value,
+    pub wasm: Option<Vec<u8>>,
+}

--- a/src/idl_loader/mod.rs
+++ b/src/idl_loader/mod.rs
@@ -1,9 +1,13 @@
 pub mod error;
 pub mod idl;
+pub mod loaded_idl;
 use error::IdlError;
+use log::warn;
 use serde_json::Value;
 
-pub fn try_load(dir: &str) -> Result<Value, IdlError> {
+use crate::idl_loader::loaded_idl::LoadedIdl;
+
+pub fn try_load(dir: &str) -> Result<Vec<LoadedIdl>, IdlError> {
     // Look for `schema` dir in the current directory and its parents
     let mut dir = std::path::PathBuf::from(dir);
     loop {
@@ -18,12 +22,51 @@ pub fn try_load(dir: &str) -> Result<Value, IdlError> {
     Err(IdlError::SchemaDirNotFound)
 }
 
-fn load_json_schema(schema_dir: &std::path::Path) -> Result<Value, IdlError> {
-    let json_files = std::fs::read_dir(schema_dir)?
-        .map(|f| f.unwrap().path())
-        .filter(|f| f.extension().unwrap_or_default() == "json")
-        .collect::<Vec<_>>();
-    let json = std::fs::read_to_string(json_files.first().unwrap())?;
+fn load_json_schema(schema_dir: &std::path::Path) -> Result<Vec<LoadedIdl>, IdlError> {
+    let json_files = std::fs::read_dir(schema_dir)?.filter_map(|entry| {
+        let entry = entry.ok()?;
+        let path = entry.path();
+        if path.extension()? == "json" {
+            Some(path)
+        } else {
+            None
+        }
+    });
+
+    let mut idls = Vec::new();
+    for file_path in json_files {
+        match load_single_json_file(&file_path) {
+            Ok(idl) => idls.push(idl),
+            Err(e) => {
+                // Log the error but continue processing other files
+                warn!("Warning: Failed to load {}: {}", file_path.display(), e);
+            }
+        }
+    }
+
+    Ok(idls)
+}
+
+fn load_single_json_file(file_path: &std::path::Path) -> Result<LoadedIdl, IdlError> {
+    let json = std::fs::read_to_string(file_path)?;
     let idl: Value = serde_json::from_str(&json)?;
-    Ok(idl)
+    // Check if there is a pre-built wasm file in the `artifacts` directory (produced by cw-optimizer)
+    // WARNING: This is a convention and may not always be present, depending on cw workspace setup. TODO: Make this configurable.
+    let artifacts_path = file_path.parent();
+    let wasm_file_path = if artifacts_path.is_some() {
+        Some(
+            artifacts_path
+                .unwrap()
+                .join("artifacts")
+                .join(file_path.file_stem().unwrap())
+                .with_extension("wasm"),
+        )
+    } else {
+        None
+    };
+    let wasm = match wasm_file_path {
+        Some(path) if path.exists() => Some(std::fs::read(path)?),
+        _ => None,
+    };
+    Ok(LoadedIdl { idl, wasm })
 }

--- a/src/idl_processor/variant_info.rs
+++ b/src/idl_processor/variant_info.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct VariantInfo {
+    pub contract_tag: String,
     pub name: String,
     pub description: String,
     pub parameters: BTreeMap<String, VariantParameter>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod cli;
+pub mod commands;
+pub(crate) mod consts;
+pub(crate) mod error;
+pub(crate) mod executable;
+pub(crate) mod idl_loader;
+pub(crate) mod idl_processor;

--- a/swagger/swagger.html
+++ b/swagger/swagger.html
@@ -98,7 +98,7 @@
                         const swaggerDocument = await fetch("/api").then((res) => res.json());
 
                         const to = window.connection.contractAddress;
-                        const functionName = req.pathName.replace("/", "");
+                        const functionName = req.pathname.split("/").pop();
 
                         if (!to && functionName != "InstantiateMsg") throw new Error("Missing required parameter: contractAddress");
                         const paramValues = [];


### PR DESCRIPTION
This pull request introduces significant changes to improve the handling of IDL (Interface Definition Language) files and their associated Wasm binaries, enabling support for multiple contracts in a workspace. The most notable updates include the refactoring of the `BuildCmd` command, the introduction of the `LoadedIdl` struct, and enhancements to the `process_idl` function to handle multiple contracts. Additionally, new error handling and logging mechanisms have been implemented to improve robustness.

### Refactoring and Enhancements to IDL Handling
* Removed the `wasm` field from `BuildCmd` and updated the `process_idl` function to handle multiple contracts using the new `LoadedIdl` struct. This allows for better scalability and separation of concerns. (`src/commands/build.rs`, [[1]](diffhunk://#diff-fecf70788e2f7552a6c0aa836593643a36d5da2acbeb4e0aad343103218668d9L15-L17) [[2]](diffhunk://#diff-fecf70788e2f7552a6c0aa836593643a36d5da2acbeb4e0aad343103218668d9L26-R23)
* Introduced the `LoadedIdl` struct in `src/idl_loader/loaded_idl.rs` to encapsulate both the IDL and optional Wasm binary for each contract. (`src/idl_loader/loaded_idl.rs`, [src/idl_loader/loaded_idl.rsR1-R5](diffhunk://#diff-bb8276728845b576b0de7afed305dd8e8438e5016c5819b7a356f7dc0567c729R1-R5))
* Updated the `try_load` function in `src/idl_loader/mod.rs` to load multiple IDL files and their associated Wasm binaries, logging warnings for any failures. (`src/idl_loader/mod.rs`, [[1]](diffhunk://#diff-9dc8b1dde85c1d9938849f26f522a694478895e65fb6be933c9585f6b0d80f6bR3-R10) [[2]](diffhunk://#diff-9dc8b1dde85c1d9938849f26f522a694478895e65fb6be933c9585f6b0d80f6bL21-R71)

### Improvements to `process_idl` and OpenAPI Generation
* Modified `process_idl` in `src/idl_processor/mod.rs` to iterate over multiple `LoadedIdl` instances, generating OpenAPI documentation for each contract with distinct tags and paths. (`src/idl_processor/mod.rs`, [[1]](diffhunk://#diff-16320b657245ad2b76a1b4232f6ca78923bf39d514fd8b145f91d21d2825cbe2L15-R22) [[2]](diffhunk://#diff-16320b657245ad2b76a1b4232f6ca78923bf39d514fd8b145f91d21d2825cbe2R42-R44)
* Enhanced the `extract_variants` and `generate_path_item` functions to include a `contract_tag` for better organization of OpenAPI paths and tags. (`src/idl_processor/mod.rs`, [[1]](diffhunk://#diff-16320b657245ad2b76a1b4232f6ca78923bf39d514fd8b145f91d21d2825cbe2L79-R101) [[2]](diffhunk://#diff-16320b657245ad2b76a1b4232f6ca78923bf39d514fd8b145f91d21d2825cbe2R278)

### Error Handling and Logging
* Added a new `PathError` variant to the `IdlError` enum for better error reporting when handling file paths. (`src/idl_loader/error.rs`, [src/idl_loader/error.rsR11-R12](diffhunk://#diff-1013984b506dc58f52df8e9355d0e9a0d5f4059604e03425061878833144b96aR11-R12))
* Introduced logging in `try_load` to warn about issues while processing individual IDL files, improving visibility into potential problems. (`src/idl_loader/mod.rs`, [src/idl_loader/mod.rsL21-R71](diffhunk://#diff-9dc8b1dde85c1d9938849f26f522a694478895e65fb6be933c9585f6b0d80f6bL21-R71))

### Miscellaneous Updates
* Updated `VariantInfo` to include a `contract_tag` field, which is used to group OpenAPI paths and tags by contract. (`src/idl_processor/variant_info.rs`, [src/idl_processor/variant_info.rsR7](diffhunk://#diff-71832194f57b3d7700095527f7d4cda57fa4efc882a67906d48b79df569e5005R7))
* Fixed a bug in the Swagger UI HTML file to correctly extract the function name from the path. (`swagger/swagger.html`, [swagger/swagger.htmlL101-R101](diffhunk://#diff-2d920000a03a49782052ef3f618bcec9a75a21d5d6cd7438cb46341dc778cb7cL101-R101))